### PR TITLE
Paper formatting references

### DIFF
--- a/paper/main.bib
+++ b/paper/main.bib
@@ -88,10 +88,10 @@
 
 @misc{noauthor_qec_nodate,
 	title = {{QEC} {Decoder} {Toolkit} - {H}-{Series}},
-	url = {https://docs.quantinuum.com/h-series/trainings/getting_started/pytket_quantinuum/qec_decoder_toolkit/Quantinuum_hseries_qec_decoder_toolkit.html?_gl=1*srcw0e*_gcl_au*MTU2MzIwMzA1NC4xNzI5NTk1NzEw},
+	url = {https://www.quantinuum.com/blog/making-fault-tolerance-a-reality-introducing-our-qec-decoder-toolkit},
 	urldate = {2024-11-20},
 	file = {QEC Decoder Toolkit - H-Series:/Users/marcusedwards/Zotero/storage/DEG3AT5Z/Quantinuum_hseries_qec_decoder_toolkit.html:text/html},
-    note = {https://docs.quantinuum.com/h-series/trainings/getting\_started/pytket\_quantinuum/qec\_decoder\_toolkit-/Quantinuum\_hseries\_qec\_decoder\_toolkit.html},
+    note = {https://www.quantinuum.com/blog/making-fault-tolerance-a-reality-introducing-our-qec-decoder-toolkit},
 }
 
 @inproceedings{qdmi,
@@ -203,6 +203,6 @@
 	author = {Aso, Noriyasu and Feluś, Karolina and Gaj, Adrian and Gokita, Shun and Góralczyk, Sławomir and Kakuko, Norihiro and Masumoto, Naoyuki and Miyaji, Kosuke and Miyanaga, Takafumi and Mori, Toshio and Noda, Kunihiro and Tsukano, Satoyuki and Ymaguchi, Masaomi and Żybort, Dobrosław},
 	month = {9},
 	title = {OQTOPUS Cloud},
-	url = {https://github.com/oqtopus-team.github.io/oqtopus-cloud},
+	url = {https://github.com/oqtopus-team/oqtopus-cloud},
 	year = {2024}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -15,10 +15,10 @@ date: 30 July 2025
 title: Enabling the Verification and Formalization of Hybrid
   Quantum-Classical Computing with OpenQASM 3.0 compatible QASM-TS 2.0
 affiliations:
- - name: University of British Columbia, Canada
-   index: 2
  - name: George Washington University, United States of America
    index: 1
+ - name: University of British Columbia, Canada
+   index: 2
 ---
 
 # Summary


### PR DESCRIPTION
Addressing points raised in #8 regarding formatting and references. In particular:

- reorders the affiliations
- adds a shorter url for the QEC decoder toolkit ref
- adds the correct url for the Oqtopus project
