### PR TITLE
Update bibliography metadata

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -9,8 +9,7 @@ tags:
   - TypeScript
   - Quantum computing
   - Compiling
-bibliography:
-  - main.bib
+bibliography: main.bib
 date: 30 July 2025
 title: Enabling the Verification and Formalization of Hybrid
   Quantum-Classical Computing with OpenQASM 3.0 compatible QASM-TS 2.0


### PR DESCRIPTION
This PR updates the paper's metadata entry for bibliography, making it a string instead of a list.
This should fix the error in the JOSS review preventing the automatic checking of references. 